### PR TITLE
Refactor safe name

### DIFF
--- a/create-client
+++ b/create-client
@@ -65,8 +65,7 @@ BIN_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 source ${BIN_DIR}/functions
 source ${BIN_DIR}/defaults.conf
 
-SAFE_NAME=`echo ${CERT_NAME} | sed 's/\*/star/g'`
-SAFE_NAME=`echo $SAFE_NAME | sed 's/[^A-Za-z0-9-]/-/g'`
+SAFE_NAME=$(to_safe_name "${CERT_NAME}")
 
 message "Creating new client certificate for '${CLIENT_NAME}' with:" \
   "CERT_NAME: '${CERT_NAME}'" \

--- a/create-client-o
+++ b/create-client-o
@@ -53,8 +53,7 @@ BIN_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 source ${BIN_DIR}/functions
 source ${BIN_DIR}/defaults.conf
 
-SAFE_NAME=`echo $CLIENT_NAME | sed 's/\*/star/g'`
-SAFE_NAME=`echo $SAFE_NAME | sed 's/[^A-Za-z0-9-]/-/g'`
+SAFE_NAME=$(to_safe_name "${CLIENT_NAME}")
 
 message "Creating new client certificate for '${CLIENT_NAME}'"
 

--- a/create-server
+++ b/create-server
@@ -74,8 +74,7 @@ source ${BIN_DIR}/functions
 source ${BIN_DIR}/defaults.conf
 
 # Sanitize the commonName to make it suitable for use in filenames
-SAFE_NAME=`echo ${SERVER_NAME} | sed 's/\*/star/g'`
-SAFE_NAME=`echo ${SAFE_NAME} | sed 's/[^A-Za-z0-9-]/-/g'`
+SAFE_NAME=$(to_safe_name "${SERVER_NAME}")
 
 message "Creating new SSL server certificate for:" \
   "commonName: '${SERVER_NAME}'" \

--- a/create-ssl
+++ b/create-ssl
@@ -76,8 +76,7 @@ source ${BIN_DIR}/functions
 source ${BIN_DIR}/defaults.conf
 
 # Sanitize the commonName to make it suitable for use in filenames
-SAFE_NAME=`echo ${SERVER_NAME} | sed 's/\*/star/g'`
-SAFE_NAME=`echo ${SAFE_NAME} | sed 's/[^A-Za-z0-9-]/-/g'`
+SAFE_NAME=$(to_safe_name "${SERVER_NAME}")
 
 message \
   "Creating new SSL server certificate for:" \

--- a/functions
+++ b/functions
@@ -42,6 +42,17 @@ function binaries() {
 }
 
 # -----------------------------------------------------------------------------
+# Create safe name for storing to filesystem
+# -----------------------------------------------------------------------------
+function to_safe_name() {
+  local input="${1}"; shift;
+  local output=
+  output=${input//\*/star}
+  output=${output//[^A-Za-z0-9-]/-}
+  echo ${output}
+}
+
+# -----------------------------------------------------------------------------
 # Replicate the existing binary directory
 # -----------------------------------------------------------------------------
 function copy_scripts() {
@@ -56,7 +67,7 @@ function copy_scripts() {
 # -----------------------------------------------------------------------------
 function override() {
   target=${1#USER_}
-  NAME=`echo $2 | sed 's/[^A-Za-z0-9-]/-/g'`
+  NAME=$(echo $2 | sed 's/[^A-Za-z0-9-]/-/g')
   eval "${target}=\$${1}"
 }
 
@@ -145,7 +156,7 @@ function generate_conf() {
   read NAME
   if [ -n "${NAME}" ]; then
     CA_NAME=${NAME}
-    CA_NAME=`echo ${CA_NAME} | sed 's/[^A-Za-z0-9-]/-/g'`
+    CA_NAME=$(echo ${CA_NAME} | sed 's/[^A-Za-z0-9-]/-/g')
   fi
 
   echo -n "2. Domain name for new CA [${CA_DOMAIN}]: "

--- a/test/test-easy-ca
+++ b/test/test-easy-ca
@@ -25,6 +25,15 @@ function test::setup() {
   [[ ! -d ${BASE_DIR} ]] && mkdir -p ${BASE_DIR}
 }
 
+function test::alternatives() {
+  local options=( "${@}" ) 
+  local alternatives=
+  for option in "${options[@]}"; do
+    alternatives+="-a ${option}"
+  done 
+  echo ${alternatives}
+}
+
 function test::create_root_ca() {
   printf "%0.0s\n" {0..10} | \
     ${WORK_DIR}/create-root-ca -d ${ROOT_CA_DIR}
@@ -36,18 +45,25 @@ function test::create_signing_ca() {
 }
 
 function test::create_server_certificate() {
+  local server_name="${1}"; shift;
+  local alternatives=$(test::alternatives "${@}")
   printf "%0.0s\n" {0..6} | \
-    ${SIGNING_CA_DIR}/bin/create-server -s \*.acme.com -a acme.com
+    ${SIGNING_CA_DIR}/bin/create-server -s "${server_name}" ${alternatives}
+      
 }
 
 function test::create_ssl_certificate() {
+  local server_name="${1}"; shift;
+  local alternatives=$(test::alternatives "${@}")
   printf "%0.0s\n" {0..6} | \
-    ${SIGNING_CA_DIR}/bin/create-ssl -s ssl.acme.com -a acme.com
+    ${SIGNING_CA_DIR}/bin/create-ssl -s ${server_name} ${alternatives}
 }
 
 function test::create_client_certificate() {
+  local client_name=${1}; shift;
+  local cert_name=${1}; shift;
   printf "%0.0s\n" {0..6} | \
-    ${SIGNING_CA_DIR}/bin/create-client -c bob -n bob_builder
+    ${SIGNING_CA_DIR}/bin/create-client -c ${client_name} -n ${cert_name}
 }
 
 function test::revoke_certificate() {
@@ -88,12 +104,12 @@ function test::final_message() {
 test::setup
 test::create_root_ca
 test::create_signing_ca
-test::create_server_certificate
-test::create_ssl_certificate
-test::create_client_certificate
-test::revoke_certificate "star-acme-com.server.crt"
-test::revoke_certificate "ssl-acme-com.server.crt"
-test::revoke_certificate "bob-builder.client.crt"
+test::create_server_certificate '*.acme.com' 'acme.com'
+test::create_ssl_certificate 'ssl.acme.com' 'acme.com'
+test::create_client_certificate 'bob' 'bob_builder'
+test::revoke_certificate 'star-acme-com.server.crt'
+test::revoke_certificate 'ssl-acme-com.server.crt'
+test::revoke_certificate 'bob-builder.client.crt'
 test::usage \
   create-client \
   create-client-o \


### PR DESCRIPTION
Summary:
  * Create function to convert safe name.
  * Use bash builtins instead of `sed`.:wq
  * Remove some hardcoding from tests.