### PR TITLE
Refactor: Remove HOME variable from the code

### DIFF
--- a/create-client
+++ b/create-client
@@ -15,6 +15,7 @@ set -o pipefail
 declare -r SCRIPT=${0##*/}
 declare    CLIENT_NAME=
 declare    CERT_NAME=
+declare    BIN_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 # -----------------------------------------------------------------------------
 # Functions
@@ -61,7 +62,6 @@ function validate_options() {
 parse_options "${@}"
 validate_options
 
-BIN_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 source ${BIN_DIR}/functions
 source ${BIN_DIR}/defaults.conf
 

--- a/create-client-o
+++ b/create-client-o
@@ -6,6 +6,7 @@
 # -----------------------------------------------------------------------------
 declare -r SCRIPT=${0##*/}
 declare    CLIENT_NAME=
+declare    BIN_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 # -----------------------------------------------------------------------------
 # Functions
@@ -49,7 +50,6 @@ function validate_options() {
 parse_options "${@}"
 validate_options
 
-BIN_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 source ${BIN_DIR}/functions
 source ${BIN_DIR}/defaults.conf
 

--- a/create-root-ca
+++ b/create-root-ca
@@ -14,6 +14,7 @@ set -o pipefail
 declare -r SCRIPT=${0##*/}
 declare -x SAN=${SAN:-}
 declare    CA_DIR=
+declare    BIN_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 # -----------------------------------------------------------------------------
 # Functions
@@ -56,18 +57,16 @@ function validate_options() {
 parse_options "${@}"
 validate_options
 
-BIN_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 source ${BIN_DIR}/functions
 [[ -f "${BIN_DIR}/defaults.conf" ]] && source ${BIN_DIR}/defaults.conf
 
-HOME=$CA_DIR
-CA_NAME=$( basename "${HOME}" )
+CA_NAME=$( basename "${CA_DIR}" )
 
-message "Creating root CA in '${HOME}'"
+message "Creating root CA in '${CA_DIR}'"
 
-init_ca_home ${HOME}
-generate_conf ${HOME}/bin/defaults.conf
-source ${HOME}/bin/defaults.conf
+init_ca_home ${CA_DIR}
+generate_conf ${CA_DIR}/bin/defaults.conf
+source ${CA_DIR}/bin/defaults.conf
 
 echo
 echo -n "Enter passphrase for encrypting root CA key: "
@@ -83,7 +82,7 @@ if [ "${PASS1}" != "${PASS2}" ]; then
 fi
 export CA_PASS=${PASS1}
 
-pushd ${HOME} > /dev/null
+pushd ${CA_DIR} > /dev/null
 
 # Generate the root CA openssl config
 template "${BIN_DIR}/templates/root.tpl" "conf/ca.conf"

--- a/create-server
+++ b/create-server
@@ -14,6 +14,7 @@ set -o pipefail
 declare -r SCRIPT=${0##*/}
 declare    SERVER_NAME=
 declare    ALT_NAME=
+declare    BIN_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 # -----------------------------------------------------------------------------
 # Functions
@@ -69,7 +70,6 @@ function validate_options() {
 parse_options "${@}"
 validate_options
 
-BIN_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 source ${BIN_DIR}/functions
 source ${BIN_DIR}/defaults.conf
 

--- a/create-signing-ca
+++ b/create-signing-ca
@@ -15,6 +15,7 @@ set -o pipefail
 declare -r SCRIPT=${0##*/}
 declare -x SAN=${SAN:-}
 declare    CA_DIR=
+declare    BIN_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 # -----------------------------------------------------------------------------
 # Functions
@@ -56,19 +57,17 @@ function validate_options() {
 parse_options "${@}"
 validate_options
 
-BIN_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 source ${BIN_DIR}/functions
 source ${BIN_DIR}/defaults.conf
 
-HOME=$CA_DIR
 PARENT=${BIN_DIR}/..
-CA_NAME=$( basename "${HOME}" )
+CA_NAME=$( basename "${CA_DIR}" )
 
-message "Creating new signing sub-CA in '${HOME}'"
+message "Creating new signing sub-CA in '${CA_DIR}'"
 
-init_ca_home ${HOME}
-generate_conf ${HOME}/bin/defaults.conf
-source ${HOME}/bin/defaults.conf
+init_ca_home ${CA_DIR}
+generate_conf ${CA_DIR}/bin/defaults.conf
+source ${CA_DIR}/bin/defaults.conf
 
 echo
 echo -n "Enter passphrase for encrypting signing CA key: "
@@ -92,9 +91,9 @@ echo
 export CA_PARENT_PASS=${PARENT_PASS}
 
 # Fully-qualify home to we can return to it later
-HOME=$( cd "${HOME}" && pwd )
+CA_DIR=$(cd "${CA_DIR}" && pwd)
 
-pushd ${HOME} > /dev/null
+pushd ${CA_DIR} > /dev/null
 
 # Generate the signing CA openssl config
 template "${BIN_DIR}/templates/signing.tpl" "conf/ca.conf"
@@ -114,8 +113,8 @@ openssl req -new -batch \
 pushd ${PARENT} > /dev/null
 openssl ca -batch -notext \
            -config conf/ca.conf \
-           -in ${HOME}/ca/ca.csr \
-           -out ${HOME}/ca/ca.crt \
+           -in ${CA_DIR}/ca/ca.csr \
+           -out ${CA_DIR}/ca/ca.crt \
            -days 3652 \
            -extensions signing_ca_ext \
            -passin env:CA_PARENT_PASS

--- a/create-ssl
+++ b/create-ssl
@@ -15,6 +15,7 @@ set -o pipefail
 declare -r SCRIPT=${0##*/}
 declare    SERVER_NAME=
 declare    ALT_NAME=
+declare    BIN_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 # -----------------------------------------------------------------------------
 # Functions
@@ -71,7 +72,6 @@ function validate_options() {
 parse_options "${@}"
 validate_options
 
-BIN_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 source ${BIN_DIR}/functions
 source ${BIN_DIR}/defaults.conf
 

--- a/revoke-cert
+++ b/revoke-cert
@@ -14,6 +14,7 @@ set -o pipefail
 declare -r SCRIPT=${0##*/}
 declare -x SAN=${SAN:-}
 declare    CERT=
+declare    BIN_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 # -----------------------------------------------------------------------------
 # Functions
@@ -56,7 +57,6 @@ function validate_options() {
 parse_options "${@}"
 validate_options
 
-BIN_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 source ${BIN_DIR}/functions
 source ${BIN_DIR}/defaults.conf
 


### PR DESCRIPTION
Summary:
  * The `HOME` is generally used on Linux.
    Replaced it with `CA_DIR`.
  * Moved `BIN_DIR` to top global variables.