### PR TITLE
Add cipher to ca.key creation

### DIFF
--- a/create-client
+++ b/create-client
@@ -18,7 +18,7 @@ declare    CERT_NAME=
 declare    SAFE_NAME=
 declare    BIN_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 declare -x SAN=""
-declare -x CA_PASS=""
+declare -x CA_PASS="${CA_PASS:-}"
 
 # -----------------------------------------------------------------------------
 # Functions

--- a/create-root-ca
+++ b/create-root-ca
@@ -16,6 +16,7 @@ declare -x SAN=${SAN:-}
 declare -r BIN_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 declare    CA_DIR=
 declare    PARENT=${BIN_DIR}/..
+declare    CA_KEY_CIPHER=${CA_KEY_CIPHER:-}
 
 # -----------------------------------------------------------------------------
 # Functions
@@ -72,6 +73,7 @@ function source_files() {
 }
 
 function create_root_ca_certificate() {
+  message "Create ${CA_TYPE} CA certificate '$(pwd)/ca/ca.crt'"
   # Create the root CA certificate
   openssl ca \
     -selfsign \
@@ -86,6 +88,7 @@ function create_root_ca_certificate() {
 }
 
 function create_signing_ca_certificate() {
+  message "Create ${CA_TYPE} CA certrificate '${CA_DIR}/ca/ca.crt'"
   pushd ${PARENT} > /dev/null
   openssl ca \
     -batch \

--- a/defaults.conf
+++ b/defaults.conf
@@ -5,3 +5,7 @@ CA_CERT_ST="California"
 CA_CERT_L="San Francisco"
 CA_CERT_O="Bogus Inc."
 CA_CERT_OU="Operations"
+
+# Specify cipher to use for ca.key.
+# See `man openssl-genrsa` for more information.
+CA_KEY_CIPHER=aes256

--- a/functions
+++ b/functions
@@ -6,8 +6,8 @@
 # print horizontal line 80 chars wide
 # -----------------------------------------------------------------------------
 function ---- {
-  printf "%0.1s" -{0..80}
-  printf "\n"
+  [[ -z ${DELIMITER:-} ]] && DELIMITER=$(printf "%0.1s" -{0..80})
+  printf "%s\n" ${DELIMITER}
 }
 
 # -----------------------------------------------------------------------------
@@ -233,6 +233,8 @@ CA_CERT_L="${CA_CERT_L}"
 CA_CERT_O="${CA_CERT_O}"
 CA_CERT_OU="${CA_CERT_OU}"
 CA_CERT_CN="${CA_CERT_CN}"
+
+CA_KEY_CIPHER=${CA_KEY_CIPHER}
 EOF
 }
 
@@ -275,7 +277,7 @@ function ask_ca_passphrase() {
   
   case ${ca_name} in
   signing) export CA_PASS=${CA_PASS:-$(@password_prompt)};;
-  root)    export CA_PARENT_PASS=${CA_PARENT_PASS:-$(@password_prompt)}::
+  root)    export CA_PARENT_PASS=${CA_PARENT_PASS:-$(@password_prompt)};;
   esac
 }
 
@@ -293,7 +295,11 @@ function copy_ca_template() {
 function create_ca_key() {
   message "Create ${CA_TYPE} CA key 'ca/private/ca.key'"
   # Create the signing CA key
-  openssl genrsa -out ca/private/ca.key -passout env:CA_PASS 2048
+  openssl genrsa \
+    ${CA_KEY_CIPHER:+-${CA_KEY_CIPHER}} \
+    -out ca/private/ca.key \
+    -passout env:CA_PASS \
+    2048
   chmod 0400 ca/private/ca.key
 }
 

--- a/test/test-easy-ca
+++ b/test/test-easy-ca
@@ -22,6 +22,10 @@ declare -r SIGNING_CA_DIR=${BASE_DIR}/signing
 declare -r DELIMITER=$(printf "%0.1s" -{1..80})
 declare    FINAL_MESSAGE=true
 
+# used for setting the password for they CA keys
+export CA_PASS=@T0pS3cr3t
+export CA_PARENT_PASS=@T0pS3cr3t
+
 # -----------------------------------------------------------------------------
 # Functions
 # -----------------------------------------------------------------------------
@@ -100,7 +104,8 @@ function test::fetch_serial() {
 }
 
 function test::create_root_ca() {
-  printf "%0.0s\n" {0..10} | \
+  echo ca-pass ${CA_PASS}
+  printf "%0.0s\n" {0..11} | \
     ${WORK_DIR}/create-root-ca -d ${ROOT_CA_DIR}
 }
 


### PR DESCRIPTION
Summary:
  * Add cipher via the `defaults.conf` file via
    variable CA_KEY_CIPHER. Default is set to `aes256`.