### PR TITLE
Add "ask_ca_passphrase 'signing'" to create-client script

### DIFF
--- a/create-client
+++ b/create-client
@@ -93,6 +93,7 @@ message "Creating new client certificate for '${CLIENT_NAME}' with:" \
 pushd ${BIN_DIR}/.. > /dev/null
 check_existing_configuration "${SAFE_NAME}" client
 create_client_conf
+ask_ca_passphrase 'signing'
 create_csr "client" "${SAFE_NAME}"
 sign_csr "client" "${SAFE_NAME}"
 popd > /dev/null

--- a/functions
+++ b/functions
@@ -288,7 +288,7 @@ function copy_ca_template() {
 # -----------------------------------------------------------------------------
 function create_ca_key() {
   # Create the signing CA key
-  openssl genrsa -out ca/private/ca.key -passout env:CA_PASS 2048
+  openssl genrsa -aes256 -out ca/private/ca.key -passout env:CA_PASS 2048
   chmod 0400 ca/private/ca.key
 }
 


### PR DESCRIPTION
Hi Urs!

I noticed that it doesn't ask for the CA password when creating client cert with create-client script. However it does so when using create-client-o script. A line needs to be added to create-client -script too to make it work.

PS. this pull request is a mess, I guess, so I think it's better if you just add the line yourself