### PR TITLE
Standardize options across all scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 [![Build](https://github.com/uroesch/easy-ca/workflows/verify-ca/badge.svg)](https://github.com/uroesch/easy-ca/actions?query=workflow%3Averify-ca)
 [![Runs on](https://img.shields.io/badge/runs%20on-Linux%20%26%20macOS-blue)](#runtime-dependencies)
-<!-- 
-[![GitHub release (latest by date including 
+<!--
+[![GitHub release (latest by date including
 pre-releases)](https://img.shields.io/github/v/release/uroesch/easy-ca?include_prereleases)](https://github.com/uroesch/easy-ca/releases)
-![GitHub All Releases](https://img.shields.io/github/downloads/uroesch/easy-ca/total?style=flat) 
+![GitHub All Releases](https://img.shields.io/github/downloads/uroesch/easy-ca/total?style=flat)
 -->
 
 # easy-ca
 OpenSSL wrapper scripts for managing basic CA functions
 
-A suite of bash scripts for automating very basic OpenSSL Certificate Authority 
+A suite of bash scripts for automating very basic OpenSSL Certificate Authority
 operations:
 * Creating Root CAs
 * Creating Intermediate Signing CAs
@@ -19,7 +19,7 @@ operations:
 
 ## Compatibilty
 
-The listed operating systems and bash version are automatically verified and 
+The listed operating systems and bash version are automatically verified and
 tested at each pull request.
 
 ## Operating Systems
@@ -53,19 +53,19 @@ Earlier versions of Bash have not been tested but will most likely not work.
 
 ### Create a new Root CA
 
-The **create-root-ca** script will initialize a new Root CA directory 
-structure. This script can be run directly from the source repo or from within 
-an existing Easy CA installation. The CA is self-contained within the specified 
-directory tree. It is portable and can be stored on removable media for 
+The **create-root-ca** script will initialize a new Root CA directory
+structure. This script can be run directly from the source repo or from within
+an existing Easy CA installation. The CA is self-contained within the specified
+directory tree. It is portable and can be stored on removable media for
 security.
 
 ```bash
-create-root-ca -d $ROOT_CA_DIR
+create-root-ca --ca-dir $ROOT_CA_DIR
 ```
 
-**create-root-ca** will prompt for the basic DN configuration to use as 
-defaults for this CA. Optionally, you can edit *defaults.conf* to set this 
-information in advance. The new CA is now ready for use. The CA key, 
+**create-root-ca** will prompt for the basic DN configuration to use as
+defaults for this CA. Optionally, you can edit *defaults.conf* to set this
+information in advance. The new CA is now ready for use. The CA key,
 certificate, and CRL are available for review:
 
 ```bash
@@ -77,16 +77,16 @@ $ROOT_CA_DIR/crl/ca.crl
 
 ### (Optional) Create an Intermediate Signing CA
 
-Running **create-signing-ca** from within a Root CA installation will 
-initialize a new Intermediate CA directory structure, indepedent and separate 
+Running **create-signing-ca** from within a Root CA installation will
+initialize a new Intermediate CA directory structure, indepedent and separate
 from the Root CA. A Root CA may issue multiple Intermediate CAs.
 
 ```bash
-$ROOT_CA_DIR/bin/create-signing-ca -d $SIGNING_CA_DIR
+$ROOT_CA_DIR/bin/create-signing-ca --ca-dir $SIGNING_CA_DIR
 ```
 
-**create-signing-ca** will prompt for basic DN configuration, using the Root CA 
-configuration as defaults. The Intermediate Signing CA is now ready for use. 
+**create-signing-ca** will prompt for basic DN configuration, using the Root CA
+configuration as defaults. The Intermediate Signing CA is now ready for use.
 The CA key, certificate, chain file, and CRL are available for review:
 
 ```bash
@@ -98,35 +98,35 @@ $SIGNING_CA_DIR/crl/ca.crl
 
 ## Using the Created Certificate Authority
 
-After the Certificate Authority has been created, the scripts should be run on 
+After the Certificate Authority has been created, the scripts should be run on
 the created CA directory (At the first run the directory must no exist).
 For example:
 
 ```bash
-create-root-ca -d /opt/CA
+create-root-ca --ca-dir /opt/CA
 cd /opt/CA/bin
-create-client -c user1@bogus.com -n user1
+create-client --cn user1@bogus.com --name user1
 ```
 
 ### Issue a Server Certificate
 
-Running **create-server** from within any CA installation will issue a new 
+Running **create-server** from within any CA installation will issue a new
 server (serverAuth) certificate:
 
 ```bash
-$CA_DIR/bin/create-server -s fqdn.domain.com
+$CA_DIR/bin/create-server --cn fqdn.domain.com
 ```
 
-Optionally, you can specify one (or more) subjectAltNames to accompany the new 
+Optionally, you can specify one (or more) subjectAltNames to accompany the new
 certificate:
 
 ```bash
-$CA_DIR/bin/create-server -s fqdn.domain.com -a alt1.domain.com -a 
-alt2.domain.com
+$CA_DIR/bin/create-server --cn fqdn.domain.com \
+  --san alt1.domain.com --san alt2.domain.com
 ```
 
-**create-server** will prompt for basic DN configuration, using the CA 
-configuration as defaults. After the script is completed, the server 
+**create-server** will prompt for basic DN configuration, using the CA
+configuration as defaults. After the script is completed, the server
 certificate, key, and CSR are available for review:
 
 ```bash
@@ -137,15 +137,15 @@ $CA_DIR/csr/fqdn-domain-com.server.csr
 
 ### Issue a Client Certificate
 
-Running **create-client** from within any CA installation will issue a new 
+Running **create-client** from within any CA installation will issue a new
 client (clientAuth) certificate:
 
 ```bash
-$CA_DIR/bin/create-client -c user@domain.com -n certname
+$CA_DIR/bin/create-client --cn user@domain.com --name certname
 ```
 
-**create-client** will prompt for basic DN configuration, using the CA 
-configuration as defaults. After the script is completed, the client 
+**create-client** will prompt for basic DN configuration, using the CA
+configuration as defaults. After the script is completed, the client
 certificate, key, and CSR are available for review:
 
 ```bash
@@ -155,26 +155,26 @@ $CA_DIR/csr/user-domain-com.client.csr
 ```
 
 ```bash
-$CA_DIR/bin/create-client -c user@domain.com
+$CA_DIR/bin/create-client --cn user@domain.com
 ```
 
 ### Revoke a Certificate
 
-Running **revoke-cert** from within a CA installation allows you to revoke a 
+Running **revoke-cert** from within a CA installation allows you to revoke a
 certificate issued by that CA and update the CRL:
 
 For Server certificates:
 ```bash
-$CA_DIR/bin/revoke-cert -c $CA_DIR/certs/fqdn-domain-com.server.crt
+$CA_DIR/bin/revoke-cert --cert-name $CA_DIR/certs/fqdn-domain-com.server.crt
 ```
 
 For Client certificates:
 ```bash
-$CA_DIR/bin/revoke-cert -c $CA_DIR/certs/certificate.client.crt
+$CA_DIR/bin/revoke-cert --cert-name $CA_DIR/certs/certificate.client.crt
 ```
 
 
-**revoke-cert** will prompt for the revocation reason. After the script is 
+**revoke-cert** will prompt for the revocation reason. After the script is
 completed, the server CRL is updated and available for review:
 
 ```bash
@@ -185,7 +185,7 @@ $CA_DIR/crl/ca.crl
 
 ## Caveats
 
-These scripts are very simple, and make some hard-coded assumptions about 
+These scripts are very simple, and make some hard-coded assumptions about
 behavior and configuration:
 * Root and Intermediate CAs have a 3652-day lifetime
 * Root and Intermediate CAs have 4096-bit RSA keys

--- a/create-client
+++ b/create-client
@@ -13,7 +13,7 @@ set -o pipefail
 # Globals
 # -----------------------------------------------------------------------------
 declare -r SCRIPT=${0##*/}
-declare    CLIENT_NAME=
+declare    CN=
 declare    CERT_NAME=
 declare    SAFE_NAME=
 declare    BIN_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
@@ -28,16 +28,16 @@ function usage() {
   cat <<USAGE
 
   Usage:
-    ${SCRIPT} -c CLIENT_NAME [-n CERT_NAME] [-h]
+    ${SCRIPT} -c COMMON_NAME [-n CERT_NAME] [-h]
 
   Description:
     Issues a client or user certificate for CLIENT_NAME.
 
   Options:
     -h | --help                     This message
-    -n | --cert-name CERT_NAME      Certificate file name for the cert.
-                                    Default: CLIENT_NAME
-    -c | --client-name CLIENT_NAME  Client name (commonName) for the cert.
+    -n | --name CERT_NAME  file name for the certifcate.
+                           Default: COMMON_NAME
+    -c | --cn COMMON_NAME  Client name (commonName) for the cert.
 
 USAGE
   exit ${exit_code}
@@ -46,22 +46,22 @@ USAGE
 function parse_options() {
   while (( $# > 0 )); do
     case ${1} in
-    -c|--client-name) shift; CLIENT_NAME=${1};;
-    -n|--cert-name)   shift; CERT_NAME=${1};;
-    -h|--help)        usage 0;;
-    *)                usage 1;;
+    -c|--cn)   shift; CN=${1};;
+    -n|--name) shift; CERT_NAME=${1};;
+    -h|--help) usage 0;;
+    *)         usage 1;;
     esac
     shift
   done
 }
 
 function validate_options() {
-  if [[ -z ${CLIENT_NAME} ]]; then
+  if [[ -z ${CN} ]]; then
     usage 1
   fi
 
   if [[ -z ${CERT_NAME} ]]; then
-    CERT_NAME=${CLIENT_NAME}
+    CERT_NAME=${CN}
   fi
 }
 
@@ -77,7 +77,7 @@ function create_safe_name() {
 
 function create_client_conf() {
   # Generate the client cert openssl config
-  export CA_USERNAME=${CLIENT_NAME}
+  export CA_USERNAME=${CN}
   template "${BIN_DIR}/templates/client.tpl" "conf/${SAFE_NAME}.client.conf"
   if [[ -z ${SAN} ]]; then
     sed -i -e 's/^\(subjectAltName.*=.*\)/#\1/' \
@@ -93,9 +93,9 @@ parse_options "${@}"
 validate_options
 source_files
 create_safe_name
-message "Creating new client certificate for '${CLIENT_NAME}' with:" \
+message "Creating new client certificate for '${CN}' with:" \
   "CERT_NAME: '${CERT_NAME}'" \
-  "CLIENT_NAME: '${CLIENT_NAME}'"
+  "CLIENT_NAME: '${CN}'"
 pushd ${BIN_DIR}/.. > /dev/null
 check_existing_configuration "${SAFE_NAME}" client
 create_client_conf

--- a/create-server
+++ b/create-server
@@ -15,8 +15,8 @@ set -o pipefail
 declare -r SCRIPT=${0##*/}
 declare    CERT_TYPE=sever
 declare    CERT_DESCRIPTION="server"
-declare    SERVER_NAME=
-declare    ALT_NAME=
+declare    CN=
+declare    SAN=
 declare    BIN_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 # -----------------------------------------------------------------------------
@@ -27,15 +27,15 @@ function usage() {
   cat <<USAGE
 
   Usage:
-    ${SCRIPT} -s SERVER_NAME [[-a ALT_NAME] ...] [-h]
+    ${SCRIPT} -s SERVER_NAME [[-S SAN] ...] [-h]
 
   Description:
     Issues a server ${CERT_DESCRIPTION} certificate for SERVER_NAME.
 
   Options:
-    -h | --help                    This message.
-    -s | --server-name SERVER_NAME Server hostname (commonName) for the cert.
-    -a | --alt-name ALT_NAME       One (or more) subjectAltNames for the cert.
+    -h | --help            This message.
+    -c | --cn COMMON_NAME  Server hostname (commonName) for the cert.
+    -s | --san SAN         One (or more) SAN (subjectAltNames) for the cert.
 
 USAGE
   exit ${exit_code}
@@ -44,26 +44,26 @@ USAGE
 function parse_options() {
   while (( $# > 0 )); do
     case ${1} in
-    -s|--server-name) shift; SERVER_NAME=${1};;
-    -a|--alt-name)    shift; ALT_NAME="${ALT_NAME}, DNS:${1}";;
-    -h|--help)        usage 0;;
-    *)                usage 1;;
+    -c|--cn)   shift; CN=${1};;
+    -s|--san)  shift; SAN="${SAN}, DNS:${1}";;
+    -h|--help) usage 0;;
+    *)         usage 1;;
     esac
     shift
   done
 }
 
 function validate_options() {
-  if [[ -z ${SERVER_NAME} ]]; then
+  if [[ -z ${CN} ]]; then
     usage 1
   fi
 }
 
-function assemble_alt_names() {
+function assemble_san() {
   # Normally an array would be used here but for
   # backward compatibilty with bash v3.0 we do it
   # the old fashioned way
-  ALT_NAME="DNS:${SERVER_NAME}${ALT_NAME}"
+  SAN="DNS:${CN}${SAN}"
 }
 
 function determine_operation_mode() {
@@ -90,17 +90,17 @@ function source_files() {
 # -----------------------------------------------------------------------------
 parse_options "${@}"
 validate_options
-assemble_alt_names
+assemble_san
 determine_operation_mode
 source_files
 
 # Sanitize the commonName to make it suitable for use in filenames
-SAFE_NAME=$(to_safe_name "${SERVER_NAME}")
+SAFE_NAME=$(to_safe_name "${CN}")
 
 message \
   "Creating new SSL server certificate for:" \
-  "commonName: '${SERVER_NAME}'" \
-  "subjectAltName: '${ALT_NAME}'"
+  "commonName: '${CN}'" \
+  "subjectAltName: '${SAN}'"
 
 pushd ${BIN_DIR}/.. > /dev/null
 
@@ -108,8 +108,8 @@ check_existing_configuration "${SAFE_NAME}" server
 ask_ca_passphrase 'signing'
 
 # Generate the server openssl config
-export CA_HOSTNAME=${SERVER_NAME}
-export SAN=${ALT_NAME}
+export CA_HOSTNAME=${CN}
+export SAN=${SAN}
 template "${BIN_DIR}/templates/${CERT_TYPE}.tpl" "conf/${SAFE_NAME}.server.conf"
 
 # Create the server key and csr and sign it

--- a/functions
+++ b/functions
@@ -266,14 +266,14 @@ function ask_ca_passphrase() {
   local ca_name=${1:-signing}
   # only use for non root CA requests
   [[ ${CA_TYPE:-} == root ]] && return 0
-  
+
   function @password_prompt() {
     printf "\nEnter passphrase for ${ca_name} CA key: " 3>&1 1>&2 2>&3
     read -s ca_pass;
     echo 3>&1 1>&2 2>&3
     echo -n "${ca_pass}"
   }
-  
+
   case ${ca_name} in
   signing) export CA_PASS=${CA_PASS:-$(@password_prompt)};;
   root)    export CA_PARENT_PASS=${CA_PARENT_PASS:-$(@password_prompt)};;

--- a/revoke-cert
+++ b/revoke-cert
@@ -25,14 +25,14 @@ function usage() {
   cat <<USAGE
 
   Usage:
-    ${SCRIPT} -c CERT_NAME [-h]
+    ${SCRIPT} -C CERT_NAME [-h]
 
   Description:
     Revokes a certificate issued by this CA.
 
   Options:
-    -h | --help                  This message. 
-    -c | --cert-name CERT_NAME   Path the the certificate file to be revoked.
+    -h | --help                  This message.
+    -C | --cert-name CERT_NAME   Path the the certificate file to be revoked.
 
 USAGE
   exit ${exit_code}
@@ -41,7 +41,7 @@ USAGE
 function parse_options() {
   while (( $# > 0 )); do
     case ${1} in
-    -c|--cert-name) shift; CERT_NAME=${1};;
+    -C|--cert-name) shift; CERT_NAME=${1};;
     -h|--help)      usage 0;;
     *)              usage 1;;
     esac

--- a/test/test-easy-ca
+++ b/test/test-easy-ca
@@ -139,7 +139,7 @@ function test::revoke-cert() {
   local certificate=${1}; shift;
   printf "1\ny\n" | \
     ${SIGNING_CA_DIR}/bin/revoke-cert \
-    -c ${SIGNING_CA_DIR}/certs/${certificate}
+    -C ${SIGNING_CA_DIR}/certs/${certificate}
 }
 
 function test::verify-revokation() {
@@ -186,12 +186,12 @@ parse_options "$@"
 test::setup
 test::create-root-ca
 test::create-signing-ca
-test::create-server -s '*.acme.com' -a 'acme.com'
+test::create-server --cn '*.acme.com' --san 'acme.com'
 test::verify-server 'star-acme-com.server.crt' {\*.,}acme.com
-test::create-ssl -s 'ssl.acme.com' -a 'acme.com'
+test::create-ssl --cn 'ssl.acme.com' --san 'acme.com'
 test::verify-ssl 'ssl-acme-com.server.crt'
-test::create-client -c 'bob@acme.com' -n 'bob_builder'
-test::create-client -c 'bobby@acme.com'
+test::create-client --cn 'bob@acme.com' --name 'bob_builder'
+test::create-client --cn 'bobby@acme.com'
 test::revoke-cert 'star-acme-com.server.crt'
 test::verify-revokation 'star-acme-com.server.crt'
 test::revoke-cert 'ssl-acme-com.server.crt'


### PR DESCRIPTION
Summary:
  * Ensure all script are using the same switches for
    the same names. E.g. `--cn` for commonName and
    `--san` for subjectAltName.
  * Update README to reflect the new switches.
  * Use long-switches in README.