### PR TITLE
Create pkcs12 for server and ssl certificates

### DIFF
--- a/create-client
+++ b/create-client
@@ -101,18 +101,6 @@ function create_client_conf() {
   fi
 }
 
-function create_pkcs12() {
-  [[ ${PKCS12} != true ]] && return || :
-  [[ -d pkcs12 ]] || mkdir pkcs12 && :
-  message "Creating PKCS12 for ${SAFE_NAME}.${CERT_SUFFIX}.crt"
-  openssl pkcs12 \
-    -export \
-    -inkey private/${SAFE_NAME}.${CERT_SUFFIX}.key \
-    -in certs/${SAFE_NAME}.${CERT_SUFFIX}.crt \
-    -out pkcs12/${SAFE_NAME}.${CERT_SUFFIX}.p12 \
-    -password env:PKCS12_PASS
-}
-
 # -----------------------------------------------------------------------------
 # Main
 # -----------------------------------------------------------------------------

--- a/create-server
+++ b/create-server
@@ -20,6 +20,8 @@ declare    CN=
 declare -x SAN="${SAN:-}"
 declare -r SAN_PREFIX="DNS"
 declare    BIN_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+declare -x PKCS12_PASS="${PKCS12_PASS:-}"
+declare    PKCS12=false
 declare    APPEND_CHAIN=false
 
 # -----------------------------------------------------------------------------
@@ -39,6 +41,7 @@ function usage() {
     -h | --help            This message.
     -c | --cn COMMON_NAME  Server hostname (commonName) for the cert.
     -s | --san SAN         One (or more) SAN (subjectAltNames) for the cert.
+    -p | --pkcs12          Create a pkcs12 bundle from key and cert.
     -a | --append-chain    Append chain if ca/chain.pm exists.
 
 
@@ -51,6 +54,7 @@ function parse_options() {
     case ${1} in
     -c|--cn)           shift; CN=${1};;
     -s|--san)          shift; SAN="${SAN}, ${SAN_PREFIX}:${1}";;
+    -p|--pkcs12)       PKCS12=true;;
     -a|--append-chain) APPEND_CHAIN=true;;
     -h|--help)         usage 0;;
     *)                 usage 1;;
@@ -114,5 +118,6 @@ template "${BIN_DIR}/templates/${CERT_TYPE}.tpl" "conf/${SAFE_NAME}.server.conf"
 create_csr "server" "${SAFE_NAME}"
 sign_csr "server" "${SAFE_NAME}"
 append_ca_chain
+create_pkcs12
 popd > /dev/null
 message "Server certificate created."

--- a/functions
+++ b/functions
@@ -385,3 +385,18 @@ function append_ca_chain() {
     cat ca/chain.pem >> certs/${SAFE_NAME}.${CERT_SUFFIX}.crt
   fi
 }
+
+# -----------------------------------------------------------------------------
+# Create a pkcs12 archive with key and certificate
+# -----------------------------------------------------------------------------
+function create_pkcs12() {
+  [[ ${PKCS12} != true ]] && return || :
+  [[ -d pkcs12 ]] || mkdir pkcs12 && :
+  message "Creating PKCS12 for ${SAFE_NAME}.${CERT_SUFFIX}.crt"
+  openssl pkcs12 \
+    -export \
+    -inkey private/${SAFE_NAME}.${CERT_SUFFIX}.key \
+    -in certs/${SAFE_NAME}.${CERT_SUFFIX}.crt \
+    -out pkcs12/${SAFE_NAME}.${CERT_SUFFIX}.p12 \
+    ${PKCS12_PASS:+-password env:PKCS12_PASS}
+}

--- a/test/test-easy-ca
+++ b/test/test-easy-ca
@@ -244,18 +244,20 @@ test::setup
 test::create-root-ca
 test::create-signing-ca
 # server cert creation and revocation
-test::create-server --cn '*.acme.com' --san 'acme.com' --append-chain
+test::create-server --cn '*.acme.com' --san 'acme.com' --append-chain --pkcs12
 test::verify-server 'star-acme-com.server.crt' {\*.,}acme.com
 test::verify-cachain 'star-acme-com.server.crt'
+test::verify-pkcs12 'star-acme-com.server.p12'
 test::revoke-cert 'star-acme-com.server.crt'
 test::verify-revokation 'star-acme-com.server.crt'
 # ssl cert creation and revocation
-test::create-ssl --cn 'ssl.acme.com' --san 'acme.com' --append-chain
+test::create-ssl --cn 'ssl.acme.com' --san 'acme.com' --append-chain --pkcs12
 test::verify-ssl 'ssl-acme-com.server.crt'
 test::verify-cachain 'ssl-acme-com.server.crt'
+test::verify-pkcs12 'ssl-acme-com.server.p12'
 test::revoke-cert 'ssl-acme-com.server.crt'
-# client cert creation and revocation
 test::verify-revokation 'ssl-acme-com.server.crt'
+# client cert creation and revocation
 test::create-client --cn 'bob@acme.com' --name 'bob_builder' --append-chain
 test::verify-client 'bob-builder.client.crt'
 test::verify-cachain 'bob-builder.client.crt'


### PR DESCRIPTION
Summary:
  * Move `create_pkcs12` to functions.
  * Add option `--pkcs12` to `create-server` and
    `create-ssl`.