### PR TITLE
Refactor declare and consolidate usage

### DIFF
--- a/create-client
+++ b/create-client
@@ -13,18 +13,18 @@ set -o pipefail
 # Globals
 # -----------------------------------------------------------------------------
 declare -r SCRIPT=${0##*/}
-declare    CN=
-declare    CA_DIR=
+declare -- CN=
+declare -- CA_DIR=
 declare -r BIN_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
-declare    CERT_NAME=
-declare    SAFE_NAME=
+declare -- CERT_NAME=
+declare -- SAFE_NAME=
 declare -r CERT_SUFFIX=client
 declare -x SAN="${SAN:-}"
 declare -r SAN_PREFIX="email"
 declare -x CA_PASS="${CA_PASS:-}"
 declare -x PKCS12_PASS="${PKCS12_PASS:-}"
-declare    PKCS12=false
-declare    APPEND_CHAIN=false
+declare -- PKCS12=false
+declare -- APPEND_CHAIN=false
 
 
 # -----------------------------------------------------------------------------
@@ -44,10 +44,10 @@ function usage() {
     -h | --help            This message
     -n | --name CERT_NAME  File name for the certifcate.
                            Default: COMMON_NAME
-    -c | --cn COMMON_NAME  Client name (commonName) for the cert.
-    -s | --san SAN         Set a subject alternative name for the cert.
+    -c | --cn COMMON_NAME  Client name (commonName) for the certificate.
+    -s | --san SAN         Set a subject alternative name for the certificate.
                            Can be used muliple times.
-    -p | --pkcs12          Create a pkcs12 bundle from key and cert.
+    -p | --pkcs12          Create a pkcs12 bundle from key and certificate.
     -a | --append-chain    Append chain if ca/chain.pm exists.
 
 

--- a/create-root-ca
+++ b/create-root-ca
@@ -14,9 +14,9 @@ set -o pipefail
 declare -r SCRIPT=${0##*/}
 declare -x SAN=${SAN:-}
 declare -r BIN_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
-declare    CA_DIR=
-declare    PARENT=${BIN_DIR}/..
-declare    CA_KEY_CIPHER=${CA_KEY_CIPHER:-}
+declare -- CA_DIR=
+declare -- PARENT=${BIN_DIR}/..
+declare -- CA_KEY_CIPHER=${CA_KEY_CIPHER:-}
 
 # -----------------------------------------------------------------------------
 # Functions

--- a/create-server
+++ b/create-server
@@ -13,16 +13,16 @@ set -o pipefail
 # Globals
 # -----------------------------------------------------------------------------
 declare -r SCRIPT=${0##*/}
-declare    CERT_TYPE=sever
-declare    CERT_DESCRIPTION="server"
+declare -- CERT_TYPE=sever
+declare -- CERT_DESCRIPTION="server"
 declare -r CERT_SUFFIX=server
-declare    CN=
+declare -- CN=
 declare -x SAN="${SAN:-}"
 declare -r SAN_PREFIX="DNS"
-declare    BIN_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+declare -- BIN_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 declare -x PKCS12_PASS="${PKCS12_PASS:-}"
-declare    PKCS12=false
-declare    APPEND_CHAIN=false
+declare -- PKCS12=false
+declare -- APPEND_CHAIN=false
 
 # -----------------------------------------------------------------------------
 # Functions
@@ -39,8 +39,9 @@ function usage() {
 
   Options:
     -h | --help            This message.
-    -c | --cn COMMON_NAME  Server hostname (commonName) for the cert.
-    -s | --san SAN         One (or more) SAN (subjectAltNames) for the cert.
+    -c | --cn COMMON_NAME  Server hostname (commonName) for the certificate.
+    -s | --san SAN         Set a subject alternative name for the certificate.
+                           Can be used muliple times.
     -p | --pkcs12          Create a pkcs12 bundle from key and cert.
     -a | --append-chain    Append chain if ca/chain.pm exists.
 

--- a/revoke-cert
+++ b/revoke-cert
@@ -12,8 +12,8 @@ set -o pipefail
 # Global
 # -----------------------------------------------------------------------------
 declare -r SCRIPT=${0##*/}
-declare    CERT_NAME=
-declare    BIN_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+declare -- CERT_NAME=
+declare -- BIN_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 declare -x SAN=${SAN:-}
 declare -x CA_PASS=${CA_PASS:-}
 

--- a/test/test-easy-ca
+++ b/test/test-easy-ca
@@ -20,7 +20,7 @@ declare -r BASE_DIR=${TEMP_DIR}/${PREFIX_DIR}${RANDOM}
 declare -r ROOT_CA_DIR=${BASE_DIR}/root
 declare -r SIGNING_CA_DIR=${BASE_DIR}/signing
 declare -r DELIMITER=$(printf "%0.1s" -{1..80})
-declare    FINAL_MESSAGE=true
+declare -- FINAL_MESSAGE=true
 
 # used for setting the password for they CA keys and pkcs12 creation
 export CA_PASS=@T0pS3cr3t


### PR DESCRIPTION
Summary:
  * Write `declare` without a switch as showm when
    issuing `typeset -p var`.
  * Use the same wording for `--san` option in usage.
  * Write out `certificate` instead of only `cert`.