### PR TITLE
Workflow: Remove ubuntu-16.04 and add macos-11

### DIFF
--- a/.github/workflows/verify-ca.yml
+++ b/.github/workflows/verify-ca.yml
@@ -23,8 +23,7 @@ jobs:
         os:
         - ubuntu-20.04
         - ubuntu-18.04
-        - ubuntu-16.04
-        #- macos-11.0
+        - macos-11.0
         - macos-10.15
 
     steps:


### PR DESCRIPTION
Summary:
  * Ubuntu 16.04 is no longer supported by github actions,
    hence the removal.
  * macos 11 is again available. Enabled again.