### PR TITLE
Bugfix: Add missing CERT_NAME variable

### DIFF
--- a/create-client
+++ b/create-client
@@ -76,9 +76,7 @@ function validate_options() {
     usage 1
   fi
 
-  if [[ -z ${CERT_NAME} ]]; then
-    CERT_NAME=${CN}
-  fi
+  CERT_NAME=${CERT_NAME:-${CN}}
 }
 
 function source_files() {

--- a/create-server
+++ b/create-server
@@ -17,6 +17,7 @@ declare -- CERT_TYPE=sever
 declare -- CERT_DESCRIPTION="server"
 declare -r CERT_SUFFIX=server
 declare -- CN=
+declare -- CERT_NAME=
 declare -x SAN="${SAN:-}"
 declare -r SAN_PREFIX="DNS"
 declare -- BIN_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
@@ -68,6 +69,8 @@ function validate_options() {
   if [[ -z ${CN} ]]; then
     usage 1
   fi
+
+  CERT_NAME=${CERT_NAME:-${CN}}
 }
 
 function determine_operation_mode() {


### PR DESCRIPTION
Summary:
  * Missing CERT_NAME variable threw error
    when certificate config was already in
    place but not the certificates.
  * Assign CERT_NAME value of CN if empty.