### PR TITLE
Add --csr-only switch

### DIFF
--- a/create-client
+++ b/create-client
@@ -24,6 +24,7 @@ declare -r SAN_PREFIX="email"
 declare -x CA_PASS="${CA_PASS:-}"
 declare -x PKCS12_PASS="${PKCS12_PASS:-}"
 declare -- PKCS12=false
+declare -- CSR_ONLY=false
 declare -- APPEND_CHAIN=false
 
 
@@ -49,6 +50,7 @@ function usage() {
                            Can be used muliple times.
     -p | --pkcs12          Create a pkcs12 bundle from key and certificate.
     -a | --append-chain    Append chain if ca/chain.pm exists.
+    -r | --csr-only        Only create a key and a certificate signing request.
 
 USAGE
   exit ${exit_code}
@@ -61,6 +63,7 @@ function parse_options() {
     -n|--name)         shift; CERT_NAME=${1};;
     -s|--san)          shift; SAN="${SAN}, ${SAN_PREFIX}:${1}";;
     -p|--pkcs12)       PKCS12=true;;
+    -r|--csr-only)     CSR_ONLY=true;;
     -h|--help)         usage 0;;
     -a|--append-chain) APPEND_CHAIN=true;;
     *)                 usage 1;;
@@ -115,6 +118,7 @@ check_existing_configuration "${SAFE_NAME}" client
 create_client_conf
 ask_ca_passphrase 'signing'
 create_csr "client" "${SAFE_NAME}"
+[[ ${CSR_ONLY} == true ]] && exit 0
 sign_csr "client" "${SAFE_NAME}"
 append_ca_chain
 create_pkcs12

--- a/create-server
+++ b/create-server
@@ -23,6 +23,7 @@ declare -r SAN_PREFIX="DNS"
 declare -- BIN_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 declare -x PKCS12_PASS="${PKCS12_PASS:-}"
 declare -- PKCS12=false
+declare -- CSR_ONLY=false
 declare -- APPEND_CHAIN=false
 
 # -----------------------------------------------------------------------------
@@ -45,6 +46,7 @@ function usage() {
                            Can be used muliple times.
     -p | --pkcs12          Create a pkcs12 bundle from key and cert.
     -a | --append-chain    Append chain if ca/chain.pm exists.
+    -r | --csr-only        Only create a key and a certificate signing request.
 
 USAGE
   exit ${exit_code}
@@ -57,6 +59,7 @@ function parse_options() {
     -s|--san)          shift; SAN="${SAN}, ${SAN_PREFIX}:${1}";;
     -p|--pkcs12)       PKCS12=true;;
     -a|--append-chain) APPEND_CHAIN=true;;
+    -r|--csr-only)     CSR_ONLY=true;;
     -h|--help)         usage 0;;
     *)                 usage 1;;
     esac
@@ -119,6 +122,7 @@ template "${BIN_DIR}/templates/${CERT_TYPE}.tpl" "conf/${SAFE_NAME}.server.conf"
 
 # Create the server key and csr and sign it
 create_csr "server" "${SAFE_NAME}"
+[[ ${CSR_ONLY} == true ]] && exit 0 || :
 sign_csr "server" "${SAFE_NAME}"
 append_ca_chain
 create_pkcs12

--- a/functions
+++ b/functions
@@ -256,6 +256,8 @@ function ask_ca_passphrase() {
   local ca_name=${1:-signing}
   # only use for non root CA requests
   [[ ${CA_TYPE:-} == root ]] && return 0
+  # Skip if only a csr request is requested
+  [[ ${CSR_ONLY:-} == true ]] && return 0
 
   function @password_prompt() {
     printf "\nEnter passphrase for ${ca_name} CA key: " 3>&1 1>&2 2>&3

--- a/test/test-easy-ca
+++ b/test/test-easy-ca
@@ -84,29 +84,36 @@ function test::certificate-file() {
 }
 
 function test::san() {
-  local certificate="${1}"; shift;
+  local file="${1}"; shift;
   local prefix="${1}"; shift;
   local -a san=( "$@" )
   for entry in "${san[@]}"; do
-    test::dump-certificate "${certificate}" | \
+    test::dump-certificate "${file}" | \
       grep -q "${prefix}:${entry}"
   done
 }
 
 function test::certificate-path() {
-  local certificate="${1}"; shift;
-  case ${certificate} in
-  *.crt) echo ${SIGNING_CA_DIR}/certs/${certificate};;
-  *.p12) echo ${SIGNING_CA_DIR}/pkcs12/${certificate};;
+  local file="${1}"; shift;
+  case ${file} in
+  *.csr) echo ${SIGNING_CA_DIR}/csr/${file};;
+  *.crt) echo ${SIGNING_CA_DIR}/certs/${file};;
+  *.p12) echo ${SIGNING_CA_DIR}/pkcs12/${file};;
   esac
 }
 
+
 function test::dump-certificate() {
-  local certificate=${1}; shift;
-  openssl x509 \
+  local file=${1}; shift;
+  case "${file}" in
+  *.csr) command=req;;
+  *.crt) command=x509;;
+  esac
+
+  openssl ${command} \
     -noout \
     -text \
-    -in $(test::certificate-path ${certificate})
+    -in $(test::certificate-path ${file})
 }
 
 function test::fetch-serial() {
@@ -132,6 +139,21 @@ function test::create-signing-ca() {
 function test::create-server() {
   printf "%0.0s\n" {0..6} | \
     ${SIGNING_CA_DIR}/bin/create-server "$@"
+}
+
+function test::verify-request() {
+  local -- request=${1}; shift;
+  local -a san=( "${@}" )
+  case "${request}" in
+  *.server.csr) type=DNS;;
+  *.client.csr) type=email;;
+  esac
+  test::certificate-file "${request}"
+  # use two greps for macos!
+  test::dump-certificate "${request}" | \
+    grep "Subject:" | \
+    grep -q "${san[0]}"
+  test::san "${request}" "${type}" "${san[@]:-}"
 }
 
 function test::verify-certificate() {
@@ -249,29 +271,39 @@ test::create-signing-ca
 # -----------------------------------------------------------------------------
 # server cert creation and revocation
 test::create-server --cn '*.acme.com' --san 'acme.com' --append-chain --pkcs12
+test::verify-request 'star-acme-com.server.csr' {\*.,}acme.com
 test::verify-server 'star-acme-com.server.crt' {\*.,}acme.com
 test::verify-cachain 'star-acme-com.server.crt'
 test::verify-pkcs12 'star-acme-com.server.p12'
 test::revoke-cert 'star-acme-com.server.crt'
 test::verify-revokation 'star-acme-com.server.crt'
+
+# server CSR only creation
+test::create-server --cn 'csr.acme.com' --san 'csr-only.acme.com' --csr-only
+test::verify-request 'csr-acme-com.server.csr' {csr,csr-only}.acme.com
+
 # ssl cert creation and revocation
 test::create-ssl --cn 'ssl.acme.com' --san 'acme.com' --append-chain --pkcs12
+test::verify-request 'ssl-acme-com.server.csr' {ssl.,}acme.com
 test::verify-ssl 'ssl-acme-com.server.crt'
 test::verify-cachain 'ssl-acme-com.server.crt'
 test::verify-pkcs12 'ssl-acme-com.server.p12'
 test::revoke-cert 'ssl-acme-com.server.crt'
 test::verify-revokation 'ssl-acme-com.server.crt'
+
 # client cert creation and revocation
-test::create-client --cn 'bob@acme.com' --name 'bob_builder' --append-chain
-test::verify-client 'bob-builder.client.crt'
-test::verify-cachain 'bob-builder.client.crt'
-test::revoke-cert 'bob-builder.client.crt'
-test::verify-revokation 'bob-builder.client.crt'
+test::create-client --cn 'wiley.e.coyote@acme.com' --name 'wiley_coyote' --append-chain
+test::verify-request 'wiley-coyote.client.csr' wiley.e.coyote@acme.com
+test::verify-client 'wiley-coyote.client.crt'
+test::verify-cachain 'wiley-coyote.client.crt'
+test::revoke-cert 'wiley-coyote.client.crt'
+test::verify-revokation 'wiley-coyote.client.crt'
 #
-test::create-client --cn 'bobby@acme.com' --san 'b@acme.com'
-test::verify-client 'bobby-acme-com.client.crt' 'b@acme.com'
-test::revoke-cert 'bobby-acme-com.client.crt'
-test::verify-revokation 'bobby-acme-com.client.crt'
+test::create-client --cn 'roadrunner@acme.com' --san 'rr@acme.com'
+test::verify-request 'roadrunner-acme-com.client.csr' {roadrunner,rr}@acme.com
+test::verify-client 'roadrunner-acme-com.client.crt' 'rr@acme.com'
+test::revoke-cert 'roadrunner-acme-com.client.crt'
+test::verify-revokation 'roadrunner-acme-com.client.crt'
 #
 test::create-client --cn 'pkcs12@acme.com' --pkcs12
 test::verify-client 'pkcs12-acme-com.client.crt'
@@ -284,29 +316,39 @@ test::verify-revokation 'pkcs12-acme-com.client.crt'
 # -----------------------------------------------------------------------------
 # server cert creation and revocation
 test::create-server -c '*.acme.net' -s 'acme.net' -a -p
+test::verify-request 'star-acme-net.server.csr' {\*.,}acme.net
 test::verify-server 'star-acme-net.server.crt' {\*.,}acme.net
 test::verify-cachain 'star-acme-net.server.crt'
 test::verify-pkcs12 'star-acme-net.server.p12'
 test::revoke-cert 'star-acme-net.server.crt'
 test::verify-revokation 'star-acme-net.server.crt'
+
+# server CSR only creation
+test::create-server -c 'csr.acme.net' -s 'csr-only.acme.net' -r
+test::verify-request 'csr-acme-net.server.csr' {csr,csr-only}.acme.net
+
 # ssl cert creation and revocation
 test::create-ssl -c 'ssl.acme.net' -s 'acme.net' -a -p
+test::verify-request 'ssl-acme-net.server.csr' {ssl.,}acme.net
 test::verify-ssl 'ssl-acme-net.server.crt'
 test::verify-cachain 'ssl-acme-net.server.crt'
 test::verify-pkcs12 'ssl-acme-net.server.p12'
 test::revoke-cert 'ssl-acme-net.server.crt'
 test::verify-revokation 'ssl-acme-net.server.crt'
+
 # client cert creation and revocation
-test::create-client -c 'bob@acme.net' -n 'bobby_builder' -a
-test::verify-client 'bobby-builder.client.crt'
-test::verify-cachain 'bobby-builder.client.crt'
-test::revoke-cert 'bobby-builder.client.crt'
-test::verify-revokation 'bobby-builder.client.crt'
+test::create-client -c 'wiley.e.coyote@acme.net' -n 'wiley_e' -a
+test::verify-request 'wiley-e.client.csr' wiley.e.coyote@acme.net
+test::verify-client 'wiley-e.client.crt'
+test::verify-cachain 'wiley-e.client.crt'
+test::revoke-cert 'wiley-e.client.crt'
+test::verify-revokation 'wiley-e.client.crt'
 #
-test::create-client -c 'bobby@acme.net' -s 'b@acme.net'
-test::verify-client 'bobby-acme-net.client.crt' 'b@acme.net'
-test::revoke-cert 'bobby-acme-net.client.crt'
-test::verify-revokation 'bobby-acme-net.client.crt'
+test::create-client -c 'roadrunner@acme.net' -s 'rr@acme.net'
+test::verify-request 'roadrunner-acme-net.client.csr' {roadrunner,rr}@acme.net
+test::verify-client 'roadrunner-acme-net.client.crt' 'rr@acme.net'
+test::revoke-cert 'roadrunner-acme-net.client.crt'
+test::verify-revokation 'roadrunner-acme-net.client.crt'
 #
 test::create-client -c 'pkcs12@acme.net' -p
 test::verify-client 'pkcs12-acme-net.client.crt'


### PR DESCRIPTION
Summary:
  * Add --csr-only switch to only create
    a key and a certificate signing request.
    This way one can use it for creating
    requests signed by another CA.