### PR TITLE
Use containers directly and update OSes

### DIFF
--- a/.github/workflows/bash-compatibility.yml
+++ b/.github/workflows/bash-compatibility.yml
@@ -1,7 +1,7 @@
 # -----------------------------------------------------------------------------
 # Verify bash compatibility
 # Author: Urs Roesch https://github.com/uroesch
-# Version: 0.2.0
+# Version: 0.3.0
 # -----------------------------------------------------------------------------
 name: bash-compatibility
 
@@ -17,35 +17,39 @@ on:
 jobs:
   bash-compatibility:
     timeout-minutes: 15
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
+    container:
+      image: bash:${{ matrix.bash }}
     strategy:
       fail-fast: false
       matrix:
-        os:
-        - ubuntu-latest
         bash:
-        - '3.0'
-        - '3.1'
-        - '3.2'
-        - '4.0'
-        - '4.1'
-        - '4.2'
-        - '4.3'
-        - '4.4'
-        - '5.0'
-        - '5.1'
+          - '3.0'
+          - '3.1'
+          - '3.2'
+          - '4.0'
+          - '4.1'
+          - '4.2'
+          - '4.3'
+          - '4.4'
+          - '5.0'
+          - '5.1'
+          - '5.2'
 
     steps:
+    - name: Install dependencies
+      shell: bash
+      run: |
+        apk add --update \
+          git \
+          git-lfs \
+          openssl
+
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         lfs: true
 
-    - name: Loop test
+    - name: Check bash compatibilty
       shell: bash
-      run: |
-        docker run \
-          --tty \
-          --volume $(pwd):/easy-ca \
-          bash:${{ matrix.bash }} \
-          bash -c "apk add --update openssl && bash /easy-ca/test/test-easy-ca"
+      run: bash test/test-easy-ca

--- a/.github/workflows/verify-ca.yml
+++ b/.github/workflows/verify-ca.yml
@@ -21,14 +21,16 @@ jobs:
     strategy:
       matrix:
         os:
+        - ubuntu-22.04
         - ubuntu-20.04
         - ubuntu-18.04
-        - macos-11.0
+        - macos-12
+        - macos-11
         - macos-10.15
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         lfs: true
 


### PR DESCRIPTION
- Use containers directly and for the bash compatibilty tests.
- Update the list of supported OSes for the verify-ca script.